### PR TITLE
Removed tests running on PRs

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - '*'
-  pull_request:
-    branches: 
-      - "main"
 
 permissions:
   contents: read


### PR DESCRIPTION
It's already running on every push, running them for PRs is redundant.